### PR TITLE
Sæt GRF som codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/ @grf
+/source/ @grf


### PR DESCRIPTION
Jeg har sat branch protection på main, der forbyder force pushes og kræver at commits merges til main via et pull request. Pull request kan kun merges hvis der findes et godkendt review fra en code owner. Medlemmer af GRF-teamet er for nuværende code owners.